### PR TITLE
add .json file extension for 2 imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const readline = require('readline');
 const cliCursor = require('cli-cursor');
-const { dashes, dots } = require('./spinners');
+const { dashes, dots } = require('./spinners.json');
 
 const { purgeSpinnerOptions, purgeSpinnersOptions, colorOptions, prefixOptions, breakText, getLinesLength, terminalSupportsUnicode, applyColor } = require('./utils');
 const { isValidStatus, writeStream, cleanStream } = require('./utils');

--- a/utils.js
+++ b/utils.js
@@ -2,7 +2,7 @@
 
 const readline = require('readline');
 const stripAnsi = require('strip-ansi');
-const { dashes, dots } = require('./spinners');
+const { dashes, dots } = require('./spinners.json');
 const chalk = require('chalk');
 
 const VALID_STATUSES = ['succeed', 'fail', 'warn', 'spinning', 'non-spinnable', 'stopped'];


### PR DESCRIPTION
While trying to bundle this package as a dependency of another Truffle package, it seems webpack has trouble resolving these two imports. Adding the `.json` file extension seems to allow webpack to correctly resolve these imports. I figure it can't hurt to add these :)